### PR TITLE
Enable driver extraction

### DIFF
--- a/src/main/java/com/github/loadtest4j/loadtest4j/DriverRequest.java
+++ b/src/main/java/com/github/loadtest4j/loadtest4j/DriverRequest.java
@@ -14,7 +14,7 @@ public final class DriverRequest {
     private final String method;
     private final String path;
 
-    DriverRequest(String body, Map<String, String> headers, String method, String path) {
+    public DriverRequest(String body, Map<String, String> headers, String method, String path) {
         this.body = body;
         this.headers = headers;
         this.method = method;


### PR DESCRIPTION
Make available any private code that client drivers need to use.

Part of #25 

Examples:

- DriverRequest constructor (currently private) - otherwise they can't test