### PR TITLE
Preserve request ordering in Driver

### DIFF
--- a/src/main/java/com/github/loadtest4j/loadtest4j/Driver.java
+++ b/src/main/java/com/github/loadtest4j/loadtest4j/Driver.java
@@ -1,10 +1,10 @@
 package com.github.loadtest4j.loadtest4j;
 
-import java.util.Collection;
+import java.util.List;
 
 /**
  * The driver that runs a load test under the covers.
  */
 public interface Driver {
-    DriverResult run(Collection<DriverRequest> requests);
+    DriverResult run(List<DriverRequest> requests);
 }

--- a/src/main/java/com/github/loadtest4j/loadtest4j/DriverAdapter.java
+++ b/src/main/java/com/github/loadtest4j/loadtest4j/DriverAdapter.java
@@ -1,7 +1,7 @@
 package com.github.loadtest4j.loadtest4j;
 
 import java.util.Arrays;
-import java.util.Collection;
+import java.util.List;
 import java.util.stream.Collectors;
 
 class DriverAdapter implements LoadTester {
@@ -13,14 +13,14 @@ class DriverAdapter implements LoadTester {
 
     @Override
     public Result run(Request... requests) {
-        final Collection<DriverRequest> driverRequests = preprocessRequests(requests);
+        final List<DriverRequest> driverRequests = preprocessRequests(requests);
 
         final DriverResult driverResult = driver.run(driverRequests);
 
         return postprocessResult(driverResult);
     }
 
-    private static Collection<DriverRequest> preprocessRequests(Request[] requests) {
+    private static List<DriverRequest> preprocessRequests(Request[] requests) {
         return Arrays.stream(requests)
                 .map(request -> new DriverRequest(request.getBody(), request.getHeaders(), request.getMethod(), request.getPath()))
                 .collect(Collectors.toList());

--- a/src/test/java/com/github/loadtest4j/loadtest4j/DriverAdapterTest.java
+++ b/src/test/java/com/github/loadtest4j/loadtest4j/DriverAdapterTest.java
@@ -1,11 +1,14 @@
 package com.github.loadtest4j.loadtest4j;
 
 import com.github.loadtest4j.loadtest4j.driver.NopDriver;
+import com.github.loadtest4j.loadtest4j.driver.SpyDriver;
 import com.github.loadtest4j.loadtest4j.junit.UnitTest;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
+
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
@@ -28,4 +31,18 @@ public class DriverAdapterTest {
         assertEquals(0, result.getRequests());
     }
 
+    @Test
+    public void testRunPreservesRequestOrdering() {
+        // Given
+        final SpyDriver driver = new SpyDriver(new NopDriver());
+        final LoadTester loadTester = new DriverAdapter(driver);
+
+        // When
+        loadTester.run(Request.get("/foo"), Request.get("/bar"));
+
+        // Then
+        final List<DriverRequest> actualRequests = driver.getActualRequests();
+        assertEquals("/foo", actualRequests.get(0).getPath());
+        assertEquals("/bar", actualRequests.get(1).getPath());
+    }
 }

--- a/src/test/java/com/github/loadtest4j/loadtest4j/driver/NopDriver.java
+++ b/src/test/java/com/github/loadtest4j/loadtest4j/driver/NopDriver.java
@@ -4,11 +4,11 @@ import com.github.loadtest4j.loadtest4j.Driver;
 import com.github.loadtest4j.loadtest4j.DriverRequest;
 import com.github.loadtest4j.loadtest4j.DriverResult;
 
-import java.util.Collection;
+import java.util.List;
 
 public class NopDriver implements Driver {
     @Override
-    public DriverResult run(Collection<DriverRequest> requests) {
+    public DriverResult run(List<DriverRequest> requests) {
         return new DriverResult(0, 0);
     }
 }

--- a/src/test/java/com/github/loadtest4j/loadtest4j/driver/SpyDriver.java
+++ b/src/test/java/com/github/loadtest4j/loadtest4j/driver/SpyDriver.java
@@ -1,0 +1,28 @@
+package com.github.loadtest4j.loadtest4j.driver;
+
+import com.github.loadtest4j.loadtest4j.Driver;
+import com.github.loadtest4j.loadtest4j.DriverRequest;
+import com.github.loadtest4j.loadtest4j.DriverResult;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SpyDriver implements Driver {
+    private List<DriverRequest> actualRequests = new ArrayList<>();
+
+    private final Driver delegate;
+
+    public SpyDriver(Driver delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public DriverResult run(List<DriverRequest> requests) {
+        this.actualRequests = requests;
+        return delegate.run(requests);
+    }
+
+    public List<DriverRequest> getActualRequests() {
+        return actualRequests;
+    }
+}


### PR DESCRIPTION
Pass a List not a Collection to the Driver to ensure that request order is preserved.

This will be necessary for drivers that want to loop over the request array continuously, and guarantee that they are running the requests in the order that the user passed in to the LoadTester interface.

Fixes #34 