### PR TITLE
Inform user when no drivers found

### DIFF
--- a/src/main/java/com/github/loadtest4j/loadtest4j/LoadTesterFactory.java
+++ b/src/main/java/com/github/loadtest4j/loadtest4j/LoadTesterFactory.java
@@ -54,6 +54,8 @@ public final class LoadTesterFactory {
     }
 
     private DriverFactory getDriverFactory() {
+        validateNotEmpty(driverFactoryScanner);
+
         validatePresenceOf(properties, Collections.singletonList(DRIVER_PROPERTY_NAMESPACE));
 
         final String driverType = properties.getProperty(DRIVER_PROPERTY_NAMESPACE);
@@ -63,6 +65,12 @@ public final class LoadTesterFactory {
 
     private Map<String, String> getDriverProperties() {
         return PropertiesSubset.getSubsetAndStripPrefix(properties, DRIVER_PROPERTY_NAMESPACE);
+    }
+
+    private static void validateNotEmpty(DriverFactoryScanner scanner) {
+        if (scanner.isEmpty()) {
+            throw new LoadTesterException("No load test drivers were found. Please add one or more drivers to your project.");
+        }
     }
 
     private static void validatePresenceOf(Map map, Collection<String> keys) {
@@ -133,6 +141,8 @@ public final class LoadTesterFactory {
 
     interface DriverFactoryScanner {
         Optional<DriverFactory> findFirst(String className);
+
+        boolean isEmpty();
     }
 
     static class DriverFactoryClasspathScanner implements DriverFactoryScanner {
@@ -159,6 +169,10 @@ public final class LoadTesterFactory {
             return FACTORIES.stream()
                     .filter(factory -> factory.getClass().getName().equals(className))
                     .findFirst();
+        }
+
+        public boolean isEmpty() {
+            return FACTORIES.isEmpty();
         }
     }
 }

--- a/src/test/java/com/github/loadtest4j/loadtest4j/LoadTesterFactoryTest.java
+++ b/src/test/java/com/github/loadtest4j/loadtest4j/LoadTesterFactoryTest.java
@@ -31,6 +31,19 @@ public class LoadTesterFactoryTest {
     @Test
     public void testCreateDriverWithNoDriverFactories() {
         final LoadTesterFactory.DriverFactoryScanner driverFactories = new MockDriverFactoryScanner();
+        final LoadTesterFactory factory = new LoadTesterFactory(driverFactories, new Properties());
+
+        thrown.expect(LoadTesterException.class);
+        thrown.expectMessage("No load test drivers were found. Please add one or more drivers to your project.");
+
+        factory.createLoadTester();
+    }
+
+    @Test
+    public void testCreateDriverWithInvalidDriverFactorySpecified() {
+        final DriverFactory stubFactory = new StubDriverFactory();
+        final LoadTesterFactory.DriverFactoryScanner driverFactories = new MockDriverFactoryScanner()
+                .add(stubFactory);
         final Properties driverProperties = singletonProperties("loadtest4j.driver", "foo");
         final LoadTesterFactory factory = new LoadTesterFactory(driverFactories, driverProperties);
 
@@ -139,6 +152,11 @@ public class LoadTesterFactoryTest {
             return factories.stream()
                     .filter(factory -> factory.getClass().getName().equals(className))
                     .findFirst();
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return factories.isEmpty();
         }
     }
 


### PR DESCRIPTION
Inform the user with an exception when no drivers are found by the scanner.

Fixes #33 