### PR TITLE
Fix driver properties validation bug

### DIFF
--- a/src/main/java/com/github/loadtest4j/loadtest4j/DriverAdapterFactory.java
+++ b/src/main/java/com/github/loadtest4j/loadtest4j/DriverAdapterFactory.java
@@ -33,9 +33,8 @@ class DriverAdapterFactory {
     private Driver createDriver(Map<String, String> properties) {
         final DriverFactory driverFactory = getDriverFactory(properties);
 
-        validatePresenceOf(properties, driverFactory.getMandatoryProperties());
-
         final Map<String, String> driverProperties = getDriverProperties(properties);
+        validatePresenceOf(driverProperties, driverFactory.getMandatoryProperties());
         final Driver driver = driverFactory.create(driverProperties);
 
         final Driver validatingDriver = new ValidatingDriver(driver);

--- a/src/test/java/com/github/loadtest4j/loadtest4j/DriverAdapterFactoryTest.java
+++ b/src/test/java/com/github/loadtest4j/loadtest4j/DriverAdapterFactoryTest.java
@@ -9,6 +9,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static org.junit.Assert.assertNotNull;
 
@@ -68,13 +69,21 @@ public class DriverAdapterFactoryTest {
 
     @Test
     public void testCreateDriver() {
-        final DriverFactory nopFactory = new NopDriverFactory();
+        // Given
+        final DriverFactory stubFactory = new StubDriverFactory();
         final DriverAdapterFactory.DriverFactoryScanner driverFactories = new MockDriverFactoryScanner()
-                .add(nopFactory);
+                .add(stubFactory);
         final DriverAdapterFactory factory = new DriverAdapterFactory(driverFactories);
 
-        final LoadTester loadTester = factory.create(Collections.singletonMap("loadtest4j.driver", nopFactory.getClass().getName()));
+        // When
+        final Map<String, String> properties = new ConcurrentHashMap<>();
+        properties.put("loadtest4j.driver", stubFactory.getClass().getName());
+        properties.put("loadtest4j.driver.bar", "1");
+        properties.put("loadtest4j.driver.foo", "2");
+        properties.put("loadtest4j.reporter.enabled", "true");
+        final LoadTester loadTester = factory.create(properties);
 
+        // Then
         assertNotNull(loadTester);
     }
 


### PR DESCRIPTION
Fix bug where driver properties validation was validating the 'all' map, not the prefix-stripped 'driver properties' map.