### PR TITLE
Expose response time percentiles in the API

### DIFF
--- a/src/main/java/com/github/loadtest4j/loadtest4j/DriverAdapter.java
+++ b/src/main/java/com/github/loadtest4j/loadtest4j/DriverAdapter.java
@@ -26,6 +26,6 @@ class DriverAdapter implements LoadTester {
     }
 
     private static Result postprocessResult(DriverResult driverResult) {
-        return new Result(driverResult.getOk(), driverResult.getKo(), driverResult.getActualDuration());
+        return new Result(driverResult.getOk(), driverResult.getKo(), driverResult.getActualDuration(), driverResult.getResponseTime());
     }
 }

--- a/src/main/java/com/github/loadtest4j/loadtest4j/DriverResult.java
+++ b/src/main/java/com/github/loadtest4j/loadtest4j/DriverResult.java
@@ -13,5 +13,7 @@ public interface DriverResult {
 
     Duration getActualDuration();
 
+    ResponseTime getResponseTime();
+
     Optional<String> getReportUrl();
 }

--- a/src/main/java/com/github/loadtest4j/loadtest4j/ResponseTime.java
+++ b/src/main/java/com/github/loadtest4j/loadtest4j/ResponseTime.java
@@ -1,0 +1,16 @@
+package com.github.loadtest4j.loadtest4j;
+
+import java.time.Duration;
+
+public interface ResponseTime {
+    /**
+     * The nth percentile response time. In other words, n% of HTTP requests finished in less time than this.
+     *
+     * Max = 100th percentile.
+     *
+     * Median = 50th percentile.
+     *
+     * Min = 0th percentile.
+     */
+    Duration getPercentile(int percentile);
+}

--- a/src/main/java/com/github/loadtest4j/loadtest4j/Result.java
+++ b/src/main/java/com/github/loadtest4j/loadtest4j/Result.java
@@ -9,11 +9,13 @@ public final class Result {
     private final long ok;
     private final long ko;
     private final Duration actualDuration;
+    private final ResponseTime responseTime;
 
-    public Result(long ok, long ko, Duration actualDuration) {
+    public Result(long ok, long ko, Duration actualDuration, ResponseTime responseTime) {
         this.ok = ok;
         this.ko = ko;
         this.actualDuration = actualDuration;
+        this.responseTime = responseTime;
     }
 
     public Duration getActualDuration() {
@@ -26,6 +28,10 @@ public final class Result {
 
     public long getOk() {
         return ok;
+    }
+
+    public ResponseTime getResponseTime() {
+        return responseTime;
     }
 
     public long getTotal() {

--- a/src/test/java/com/github/loadtest4j/loadtest4j/ResultTest.java
+++ b/src/test/java/com/github/loadtest4j/loadtest4j/ResultTest.java
@@ -1,6 +1,7 @@
 package com.github.loadtest4j.loadtest4j;
 
 import com.github.loadtest4j.loadtest4j.junit.UnitTest;
+import com.github.loadtest4j.loadtest4j.test_utils.NopResponseTime;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -13,28 +14,28 @@ public class ResultTest {
 
     @Test
     public void testGetTotal() {
-        final Result result = new Result(1, 1, Duration.ZERO);
+        final Result result = new Result(1, 1, Duration.ZERO, new NopResponseTime());
 
         assertEquals(2, result.getTotal());
     }
 
     @Test
     public void testGetPercentKo() {
-        final Result result = new Result(0, 2, Duration.ZERO);
+        final Result result = new Result(0, 2, Duration.ZERO, new NopResponseTime());
 
         assertEquals(100, result.getPercentKo(), 0.001);
     }
 
     @Test
     public void testGetPercentKoAvoidsDivideByZero() {
-        final Result result = new Result(0, 0, Duration.ZERO);
+        final Result result = new Result(0, 0, Duration.ZERO, new NopResponseTime());
 
         assertEquals(0, result.getPercentKo(), 0.001);
     }
 
     @Test
     public void testGetPercentKoWithErrors() {
-        final Result result = new Result(3, 1, Duration.ZERO);
+        final Result result = new Result(3, 1, Duration.ZERO, new NopResponseTime());
 
         assertEquals(25, result.getPercentKo(), 0.001);
     }
@@ -44,29 +45,36 @@ public class ResultTest {
         final long ok = Long.MAX_VALUE / 2;
         final long ko = Long.MAX_VALUE / 2;
 
-        final Result result = new Result(ok, ko, Duration.ZERO);
+        final Result result = new Result(ok, ko, Duration.ZERO, new NopResponseTime());
 
         assertEquals(50, result.getPercentKo(), 0.001);
     }
 
     @Test
     public void testGetActualDuration() {
-        final Result result = new Result(1, 1, Duration.ofSeconds(2));
+        final Result result = new Result(1, 1, Duration.ofSeconds(2), new NopResponseTime());
 
         assertEquals(Duration.ofSeconds(2), result.getActualDuration());
     }
 
     @Test
     public void testGetRequestsPerSecond() {
-        final Result result = new Result(5, 5, Duration.ofMillis(2500));
+        final Result result = new Result(5, 5, Duration.ofMillis(2500), new NopResponseTime());
 
         assertEquals(4, result.getRequestsPerSecond(), 0.001);
     }
 
     @Test
     public void testGetRequestsPerSecondAvoidsDivideByZero() {
-        final Result result = new Result(2, 0, Duration.ZERO);
+        final Result result = new Result(2, 0, Duration.ZERO, new NopResponseTime());
 
         assertEquals(0, result.getRequestsPerSecond(), 0.001);
+    }
+
+    @Test
+    public void testGetResponseTime() {
+        final Result result = new Result(2, 0, Duration.ZERO, new NopResponseTime());
+
+        assertEquals(Duration.ZERO, result.getResponseTime().getPercentile(50));
     }
 }

--- a/src/test/java/com/github/loadtest4j/loadtest4j/test_utils/NopDriver.java
+++ b/src/test/java/com/github/loadtest4j/loadtest4j/test_utils/NopDriver.java
@@ -3,6 +3,7 @@ package com.github.loadtest4j.loadtest4j.test_utils;
 import com.github.loadtest4j.loadtest4j.Driver;
 import com.github.loadtest4j.loadtest4j.DriverRequest;
 import com.github.loadtest4j.loadtest4j.DriverResult;
+import com.github.loadtest4j.loadtest4j.ResponseTime;
 
 import java.time.Duration;
 import java.util.List;
@@ -29,6 +30,11 @@ public class NopDriver implements Driver {
         @Override
         public Duration getActualDuration() {
             return Duration.ZERO;
+        }
+
+        @Override
+        public ResponseTime getResponseTime() {
+            return new NopResponseTime();
         }
 
         @Override

--- a/src/test/java/com/github/loadtest4j/loadtest4j/test_utils/NopResponseTime.java
+++ b/src/test/java/com/github/loadtest4j/loadtest4j/test_utils/NopResponseTime.java
@@ -1,0 +1,12 @@
+package com.github.loadtest4j.loadtest4j.test_utils;
+
+import com.github.loadtest4j.loadtest4j.ResponseTime;
+
+import java.time.Duration;
+
+public class NopResponseTime implements ResponseTime {
+    @Override
+    public Duration getPercentile(int percentile) {
+        return Duration.ZERO;
+    }
+}

--- a/src/test/java/com/github/loadtest4j/loadtest4j/test_utils/TestDriverResult.java
+++ b/src/test/java/com/github/loadtest4j/loadtest4j/test_utils/TestDriverResult.java
@@ -1,6 +1,7 @@
 package com.github.loadtest4j.loadtest4j.test_utils;
 
 import com.github.loadtest4j.loadtest4j.DriverResult;
+import com.github.loadtest4j.loadtest4j.ResponseTime;
 
 import java.time.Duration;
 import java.util.Optional;
@@ -9,17 +10,20 @@ public class TestDriverResult implements DriverResult {
 
     private final long ok;
     private final long ko;
+    private final ResponseTime responseTime;
     private final Optional<String> reportUrl;
 
     public TestDriverResult(long ok, long ko) {
         this.ok = ok;
         this.ko = ko;
+        this.responseTime = new NopResponseTime();
         this.reportUrl = Optional.empty();
     }
 
     public TestDriverResult(long ok, long ko, String reportUrl) {
         this.ok = ok;
         this.ko = ko;
+        this.responseTime = new NopResponseTime();
         this.reportUrl = Optional.of(reportUrl);
     }
 
@@ -36,6 +40,11 @@ public class TestDriverResult implements DriverResult {
     @Override
     public Duration getActualDuration() {
         return Duration.ZERO;
+    }
+
+    @Override
+    public ResponseTime getResponseTime() {
+        return responseTime;
     }
 
     @Override


### PR DESCRIPTION
Fixes #60 

This initial approach only exposes response time percentiles to whole-number precision (e.g. p99). It does not attempt to do decimal precision (e.g. p99.999), because this will require further thought for the drivers that cannot access their raw histogram data (e.g. wrk).