### PR TITLE
Add Gil Tene’s load test archetypes to docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,9 +9,9 @@ A simple load test facade for Java.
 ## Contents
 
 - Concepts
-  - [Executable SLA](concepts/sla.md)
   - [Scenario](concepts/scenario.md)
-  - [Service Under Test](concepts/sut.md)
+  - [Service Level Agreement (SLA)](concepts/sla.md)
+  - [Service Under Test (SUT)](concepts/sut.md)
 - [Drivers](drivers.md)
 - [Manifesto](manifesto.md)
 - [Multiple Drivers support](multiple-drivers.md)

--- a/docs/concepts/sla.md
+++ b/docs/concepts/sla.md
@@ -22,7 +22,7 @@ This is measured in terms of **percentiles**. For example, if the SLA defines a 
 
 The percentiles measured in the SLA depend on the purpose of the service.
 
-Response Time SLAs generally fall under one of Gil Tene's archetypes. He provides an excellent introduction to service performance archetypes in his presentatation ['How not to measure latency'](https://www.infoq.com/presentations/latency-pitfalls). They are summarised below.
+Service Response Time requirements generally fall under one of the following archetypes. For more detail, see Gil Tene's excellent presentation ['How not to measure latency'](https://www.infoq.com/presentations/latency-pitfalls).
 
 #### Archetype: Athlete
 

--- a/docs/concepts/sla.md
+++ b/docs/concepts/sla.md
@@ -20,42 +20,47 @@ The maximum amount of time that requests are allowed to take.
 
 This is measured in terms of **percentiles**. For example, if the SLA defines a 95th percentile response time of 500ms, this means 95% of requests must complete in 500ms or less, while 5% may take longer.
 
-The percentiles measured in the SLA depend on the purpose of the service. Gil Tene provides an excellent introduction to this in his presentatation ['How not to measure latency'](https://www.infoq.com/presentations/latency-pitfalls). To illustrate the difference, here are Gil's load test archetypes:
+The percentiles measured in the SLA depend on the purpose of the service.
 
-#### Athlete
+## Archetypes
+
+Gil Tene provides an excellent introduction to service performance archetypes in his presentatation ['How not to measure latency'](https://www.infoq.com/presentations/latency-pitfalls). They are summarised below.
+
+### Athlete
 
 **Goal: Win some gold medals.**
 
-Key percentiles:
+Key measurements:
 
 - TODO add
 
-#### Pacemaker (hard real-time)
+### Pacemaker (hard real-time)
 
 **Goal: Keep the heart beating.**
 
-Key percentiles:
+Key measurements:
 
-- Max (p100)
+- Percent KO = 0
+- Max Response Time (p100)
 
-#### Trader (soft real-time)
+### Trader (soft real-time)
 
 **Goals: Be fast enough to make some good trades. Contain risk while you do it.**
 
-Key percentiles:
+Key measurements:
 
-- Median (p50)
-- Max (p100)
+- Median Response Time (p50)
+- Max Response Time (p100)
 
-#### Interactive App (squishy real-time)
+### Interactive App (squishy real-time)
 
 **Goal: Keep users happy (don’t make them leave).**
 
-Key percentiles:
+Key measurements:
 
-- p90
-- p99
-- Max (p100)
+- p90 Response Time
+- p99 Response Time
+- Max Response Time (p100)
 
 ## Sidenote: The executable SLA
 

--- a/docs/concepts/sla.md
+++ b/docs/concepts/sla.md
@@ -1,23 +1,64 @@
-# Executable SLA
+# Service Level Agreement (SLA)
 
-Loadtest4j allows you to make your Service Level Agreement (SLA) **executable**.
+The performance guarantees that you provide to clients of your service.
 
-When you write a test case with assertions on the load test `Result`, you reify a part of that SLA in an executable and verifiable form.
+## Measurements
 
 An effective SLA should include one or more of the following measurements. Collaborate with your project stakeholders to choose the appropriate measurements for your service. 
 
-## Knockout Rate
+### Knockout Rate
 
 The percentage of requests that are allowed to fail (also called the 'percent KO').
 
-## Requests Per Second
+### Requests Per Second
 
 The minimum acceptable throughput for your service.
 
-## Response Time
+### Response Time
 
 The maximum amount of time that requests are allowed to take.
 
 This is measured in terms of **percentiles**. For example, if the SLA defines a 95th percentile response time of 500ms, this means 95% of requests must complete in 500ms or less, while 5% may take longer.
 
-The percentiles measured in the SLA depend on the purpose of the service. Gil Tene provides an excellent introduction to this in his presentatation ['How not to measure latency'](https://www.infoq.com/presentations/latency-pitfalls).
+The percentiles measured in the SLA depend on the purpose of the service. Gil Tene provides an excellent introduction to this in his presentatation ['How not to measure latency'](https://www.infoq.com/presentations/latency-pitfalls). To illustrate the difference, here are Gil's load test archetypes:
+
+#### Athlete
+
+**Goal: Win some gold medals.**
+
+Key percentiles:
+
+- TODO add
+
+#### Pacemaker (hard real-time)
+
+**Goal: Keep the heart beating.**
+
+Key percentiles:
+
+- Max (p100)
+
+#### Trader (soft real-time)
+
+**Goals: Be fast enough to make some good trades. Contain risk while you do it.**
+
+Key percentiles:
+
+- Median (p50)
+- Max (p100)
+
+#### Interactive App (squishy real-time)
+
+**Goal: Keep users happy (don’t make them leave).**
+
+Key percentiles:
+
+- p90
+- p99
+- Max (p100)
+
+## Sidenote: The executable SLA
+
+Loadtest4j makes your Service Level Agreement (SLA) **executable**.
+
+When you write a test case with assertions on the load test `Result`, you reify a part of that SLA in an executable and verifiable form.

--- a/docs/concepts/sla.md
+++ b/docs/concepts/sla.md
@@ -20,9 +20,7 @@ The maximum amount of time that requests are allowed to take.
 
 This is measured in terms of **percentiles**. For example, if the SLA defines a 95th percentile response time of 500ms, this means 95% of requests must complete in 500ms or less, while 5% may take longer.
 
-The percentiles measured in the SLA depend on the purpose of the service.
-
-Service Response Time requirements generally fall under one of the following archetypes. For more detail, see Gil Tene's excellent presentation ['How not to measure latency'](https://www.infoq.com/presentations/latency-pitfalls).
+The percentiles measured in the SLA depend on the purpose of the service. There is no 'one size fits all' set of percentiles to measure. That said, most services resemble one of the following archetypes, which you can use as a starting point. For more detail, see Gil Tene's excellent presentation ['How not to measure latency'](https://www.infoq.com/presentations/latency-pitfalls).
 
 #### Archetype: Athlete
 
@@ -40,6 +38,8 @@ Key percentiles:
 
 *Goal: Keep the heart beating.*
 
+The worst case is all that matters.
+
 Key percentiles:
 
 - Max (p100)
@@ -47,6 +47,8 @@ Key percentiles:
 #### Archetype: Trader (soft real-time)
 
 *Goals: Be fast enough to make some good trades. Contain risk while you do it.*
+
+The Trader must 'typically' react quickly to open a position. But their 'max' must be reasonable too, to avoid getting stuck with a bad open position.
 
 Key percentiles:
 
@@ -56,6 +58,8 @@ Key percentiles:
 #### Archetype: Interactive App (squishy real-time)
 
 *Goal: Keep users happy (don’t make them leave).*
+
+The App must be 'typically' snappy. It's OK to take longer sometimes - but not too long, and not too often.
 
 Key percentiles:
 

--- a/docs/concepts/sla.md
+++ b/docs/concepts/sla.md
@@ -22,45 +22,42 @@ This is measured in terms of **percentiles**. For example, if the SLA defines a 
 
 The percentiles measured in the SLA depend on the purpose of the service.
 
-## Archetypes
+Response Time SLAs generally fall under one of Gil Tene's archetypes. He provides an excellent introduction to service performance archetypes in his presentatation ['How not to measure latency'](https://www.infoq.com/presentations/latency-pitfalls). They are summarised below.
 
-Gil Tene provides an excellent introduction to service performance archetypes in his presentatation ['How not to measure latency'](https://www.infoq.com/presentations/latency-pitfalls). They are summarised below.
+#### Archetype: Athlete
 
-### Athlete
+*Goal: Win some gold medals.*
 
-**Goal: Win some gold medals.**
-
-Key measurements:
+Key percentiles:
 
 - TODO add
 
-### Pacemaker (hard real-time)
+#### Archetype: Pacemaker (hard real-time)
 
-**Goal: Keep the heart beating.**
+*Goal: Keep the heart beating.*
 
-Key measurements:
+Key percentiles:
 
-- Percent KO = 0
-- Max Response Time (p100)
+- Max (p100)
 
-### Trader (soft real-time)
+#### Archetype: Trader (soft real-time)
 
-**Goals: Be fast enough to make some good trades. Contain risk while you do it.**
+*Goals: Be fast enough to make some good trades. Contain risk while you do it.*
 
-Key measurements:
+Key percentiles:
 
-- Median Response Time (p50)
-- Max Response Time (p100)
+- Median (p50)
+- Max (p100)
 
-### Interactive App (squishy real-time)
+#### Archetype: Interactive App (squishy real-time)
 
-**Goal: Keep users happy (don’t make them leave).**
+*Goal: Keep users happy (don’t make them leave).*
 
-Key measurements:
+Key percentiles:
 
-- p90 Response Time
-- p99 Response Time
-- Max Response Time (p100)
+- p90
+- p99
+- Max (p100)
 
 ## Sidenote: The executable SLA
 

--- a/docs/concepts/sla.md
+++ b/docs/concepts/sla.md
@@ -28,9 +28,13 @@ Response Time SLAs generally fall under one of Gil Tene's archetypes. He provide
 
 *Goal: Win some gold medals.*
 
+The Athlete needs to be faster than everyone else in N% of races. Where N = desired percentage of races to win.
+
+Example: There are 5 races. The Athlete wants to win 3 gold medals. So they must be faster than all their competitors in 60% of races. N = 60.
+
 Key percentiles:
 
-- TODO add
+- pN
 
 #### Archetype: Pacemaker (hard real-time)
 

--- a/docs/scala.md
+++ b/docs/scala.md
@@ -18,8 +18,8 @@ Then write your load test.
 
 We recommend the following pattern of:
 
-- One API usage definition per Spec class
-- One SLA assertion per test in that class
+- One [Scenario](concepts/scenario.md) per Spec class
+- One [SLA](concepts/sla.md) assertion per test in that class
 
 ```scala
 class FindPetsLoadSpec extends FlatSpec with Matchers {


### PR DESCRIPTION
Fixes #63 

The SLA for response times is not something we can put into the domain layer of the library, because a JUnit test with assertions on the response times **is** the SLA (in executable form).

It doesn’t really make sense to provide archetype classes to be inherited from since this will monopolise the inheritance slot on the test case that library users might want to use for something else.

Also, the key response time percentiles are only a start, and the user must tailor them to the actual percentiles their specific needs.

Therefore we are better off adding these archetypes to the SLA concept documentation to **educate** library users, rather than adding them to the code itself.