### PR TITLE
Replace (negative) percentKo with (positive) percentOk

### DIFF
--- a/docs/concepts/sla.md
+++ b/docs/concepts/sla.md
@@ -8,9 +8,9 @@ Side note: loadtest4j makes your SLA **executable**. When you write a test case 
 
 An effective SLA should include one or more of the following measurements. Collaborate with your project stakeholders to choose the appropriate measurements for your service. 
 
-### Knockout Rate
+### Success Rate
 
-The percentage of requests that are allowed to fail (also called the 'percent KO').
+The minimum percentage of requests that must work (also called the 'percent OK').
 
 ### Requests Per Second
 

--- a/docs/java.md
+++ b/docs/java.md
@@ -19,6 +19,7 @@ public class PetStoreTest {
         assertSoftly(s -> {
             s.assertThat(result.getRequestsPerSecond()).as("Requests Per Second").isGreaterThanOrEqualTo(1);
             s.assertThat(result.getResponseTime().getPercentile(75)).as("p75 Response Time").isLessThanOrEqualTo(Duration.ofMillis(500));
+            s.assertThat(result.getPercentOk()).as("Percent OK").isGreaterThanOrEqualTo(99.99);
             // and so on...
         });
     }
@@ -51,10 +52,17 @@ public class FindPetsTest {
     public void testP75ResponseTime() {
         assertThat(result.get().getResponseTime().getPercentile(75)).isLessThanOrEqualTo(Duration.ofMillis(500));
     }
+    
+    @Test
+    public void testPercentOk() {
+        assertThat(result.get().getPercentOk()).isGreaterThanOrEqualTo(99.99);
+    }
 }
 ```
 
-To use this style you need to make up for the lack of lazy evaluation in Java. You should encapsulate the `lazy val` emulation in a utility class like this:
+To use this style you need to defer load test execution until a test requires it, to avoid blocking test suite initialization while the LoadTester executes.
+
+Java does not yet support lazy evaluation, so we must emulate this with a utility function that returns a `Supplier<Result>`. Here is an example:
 
 ```java
 public class LazyLoadTester {

--- a/docs/scala.md
+++ b/docs/scala.md
@@ -33,8 +33,8 @@ class FindPetsLoadSpec extends FlatSpec with Matchers {
   // You do not want this to block class initialization.
   private lazy val result = LoadTester.run(Seq(request))        
   
-  it should "meet the Percent KO threshold" in {
-    result.getPercentKo should be <= 0.01
+  it should "meet the Percent OK threshold" in {
+    result.getPercentOk should be >= 99.99
   }
   
   it should "meet the Requests Per Second threshold" in {

--- a/src/main/java/com/github/loadtest4j/loadtest4j/Result.java
+++ b/src/main/java/com/github/loadtest4j/loadtest4j/Result.java
@@ -27,14 +27,14 @@ public final class Result {
     }
 
     /**
-     * @return The percent of requests that were KO (represented as a number between 0 and 100)
+     * @return The percent of requests that were OK (represented as a number between 0 and 100)
      */
-    public double getPercentKo() {
+    public double getPercentOk() {
         // Do not divide by zero
         if (getTotal() == 0) {
             return 0;
         } else {
-            return ((double) ko) / ((double) getTotal()) * 100;
+            return ((double) ok) / ((double) getTotal()) * 100;
         }
     }
 

--- a/src/test/java/com/github/loadtest4j/loadtest4j/ResultTest.java
+++ b/src/test/java/com/github/loadtest4j/loadtest4j/ResultTest.java
@@ -20,34 +20,34 @@ public class ResultTest {
     }
 
     @Test
-    public void testGetPercentKo() {
-        final Result result = new Result(0, 2, Duration.ZERO, createResponseTime());
+    public void testGetPercentOk() {
+        final Result result = new Result(2, 0, Duration.ZERO, createResponseTime());
 
-        assertThat(result.getPercentKo()).isEqualTo(100);
+        assertThat(result.getPercentOk()).isEqualTo(100);
     }
 
     @Test
-    public void testGetPercentKoAvoidsDivideByZero() {
+    public void testGetPercentOkAvoidsDivideByZero() {
         final Result result = new Result(0, 0, Duration.ZERO, createResponseTime());
 
-        assertThat(result.getPercentKo()).isEqualTo(0);
+        assertThat(result.getPercentOk()).isEqualTo(0);
     }
 
     @Test
-    public void testGetPercentKoWithErrors() {
-        final Result result = new Result(3, 1, Duration.ZERO, createResponseTime());
+    public void testGetPercentOkWithErrors() {
+        final Result result = new Result(1, 3, Duration.ZERO, createResponseTime());
 
-        assertThat(result.getPercentKo()).isEqualTo(25);
+        assertThat(result.getPercentOk()).isEqualTo(25);
     }
 
     @Test
-    public void testGetPercentKoWithHugeNumbers() {
+    public void testGetPercentOkWithHugeNumbers() {
         final long ok = Long.MAX_VALUE / 2;
         final long ko = Long.MAX_VALUE / 2;
 
         final Result result = new Result(ok, ko, Duration.ZERO, createResponseTime());
 
-        assertThat(result.getPercentKo()).isEqualTo(50);
+        assertThat(result.getPercentOk()).isEqualTo(50);
     }
 
     @Test


### PR DESCRIPTION
Make the Result API more conceptually consistent.

Fixes #88 