### PR TITLE
Allow user to attach custom reporters to a LoadTester

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -133,13 +133,14 @@ The benefits include...
 
 ```java
 public class PetStoreLT {
-
     @Test
     public void testAddPet() {
-        BodyPart fooTxt = BodyPart.file(Paths.get("foo.txt"));
-        BodyPart barTxt = BodyPart.file(Paths.get("bar.txt"));
+        // Attach an arbitrary number of string parts and file parts.
+        BodyPart stringPart = BodyPart.string("name", "content");
+        BodyPart filePart = BodyPart.file(Paths.get("foo.txt"));
         
-        Request request = Request.post("/pets").withBody(fooTxt, barTxt);
+        Request request = Request.post("/pets")
+                                 .withBody(stringPart, filePart);
     }
 }
 ```
@@ -148,7 +149,6 @@ public class PetStoreLT {
 
 ```java
 public class PetStoreLT {
-
     // Note: Reporters are distributed separately.
     private static final LoadTester loadTester = new LoadTesterDecorator()
         .add(new Logger())

--- a/docs/README.md
+++ b/docs/README.md
@@ -131,28 +131,32 @@ The benefits include...
 
 ### Multipart requests
 
+Attach an arbitrary number of string parts or file parts to the multipart request body.
+
 ```java
 public class PetStoreLT {
     @Test
     public void shouldAddPet() {
-        // Attach an arbitrary number of string parts and file parts.
         BodyPart stringPart = BodyPart.string("name", "content");
         BodyPart filePart = BodyPart.file(Paths.get("foo.txt"));
         
-        Request request = Request.post("/pets")
-                                 .withBody(stringPart, filePart);
+        Request request = Request.post("/pets").withBody(stringPart, filePart);
     }
 }
 ```
 
-### Reporters
+### Decorator
+
+Attach custom behaviors to a `LoadTester` using the decorator. The behaviors will execute after each invocation of that 
+`LoadTester`. This feature can be used for a wide variety of tasks, such as logging or visualising a `Result`.
+
+Note: Custom behaviors are not included with the core library.
 
 ```java
 public class PetStoreLT {
-    // Note: Reporters are distributed separately.
     private static final LoadTester loadTester = new LoadTesterDecorator()
-        .add(new Logger())
-        .add(new Grapher())
+        .add(new CustomReporter())
+        .add(new HtmlReporter())
         .decorate(LoadTesterFactory.getLoadTester());
 }
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -126,3 +126,33 @@ The benefits include...
     # Run load tests
     mvn test-compile surefire:test@load
     ```
+
+## Advanced usage
+
+### Multipart requests
+
+```java
+public class PetStoreLT {
+
+    @Test
+    public void testAddPet() {
+        BodyPart fooTxt = BodyPart.file(Paths.get("foo.txt"));
+        BodyPart barTxt = BodyPart.file(Paths.get("bar.txt"));
+        
+        Request request = Request.post("/pets").withBody(fooTxt, barTxt);
+    }
+}
+```
+
+### Reporters
+
+```java
+public class PetStoreLT {
+
+    // Note: Reporters are distributed separately.
+    private static final LoadTester loadTester = new LoadTesterDecorator()
+        .add(new Logger())
+        .add(new Grapher())
+        .decorate(LoadTesterFactory.getLoadTester());
+}
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -69,7 +69,7 @@ The benefits include...
         private static final LoadTester loadTester = LoadTesterFactory.getLoadTester();
     
         @Test
-        public void testFindPets() {
+        public void shouldFindPets() {
             List<Request> requests = List.of(Request.get("/pet/findByStatus")
                                                     .withHeader("Accept", "application/json")
                                                     .withQueryParam("status", "available"));
@@ -134,7 +134,7 @@ The benefits include...
 ```java
 public class PetStoreLT {
     @Test
-    public void testAddPet() {
+    public void shouldAddPet() {
         // Attach an arbitrary number of string parts and file parts.
         BodyPart stringPart = BodyPart.string("name", "content");
         BodyPart filePart = BodyPart.file(Paths.get("foo.txt"));

--- a/docs/guides/junit.md
+++ b/docs/guides/junit.md
@@ -13,7 +13,7 @@ public class PetStoreTest {
     private static final LoadTester loadTester = LoadTesterFactory.getLoadTester();
     
     @Test
-    public void testFindPets() {
+    public void shouldFindPets() {
         final Result result = loadTester.run(requests);
         
         assertSoftly(s -> {
@@ -43,12 +43,12 @@ public class FindPetsTest {
     private static final Supplier<Result> result = LazyLoadTester.run(requests);
    
     @Test
-    public void testP75ResponseTime() {
+    public void shouldSatisfyP75ResponseTimeThreshold() {
         assertThat(result.get().getResponseTime().getPercentile(75)).isLessThanOrEqualTo(Duration.ofMillis(500));
     }
     
     @Test
-    public void testPercentOk() {
+    public void shouldSatisfyPercentOkThreshold() {
         assertThat(result.get().getPercentOk()).isGreaterThanOrEqualTo(99.99);
     }
 }

--- a/src/main/java/org/loadtest4j/decorator/LoadTesterDecorator.java
+++ b/src/main/java/org/loadtest4j/decorator/LoadTesterDecorator.java
@@ -1,0 +1,59 @@
+package org.loadtest4j.decorator;
+
+import org.loadtest4j.LoadTester;
+import org.loadtest4j.Request;
+import org.loadtest4j.Result;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Attach auxiliary behavior to a {@link LoadTester}. This behavior will run every time that the decorated
+ * {@link LoadTester} runs.
+ */
+public class LoadTesterDecorator {
+
+    private final List<Reporter> reporters;
+
+    private LoadTesterDecorator(List<Reporter> reporters) {
+        this.reporters = reporters;
+    }
+
+    public LoadTesterDecorator() {
+        this(Collections.emptyList());
+    }
+
+    public LoadTesterDecorator add(Reporter reporter) {
+        return new LoadTesterDecorator(concatenate(reporters, reporter));
+    }
+
+    public LoadTester decorate(LoadTester loadTester) {
+        return new DecoratedLoadTester(loadTester, reporters);
+    }
+
+    private static <T> List<T> concatenate(List<T> list, T element) {
+        return Stream.concat(list.stream(), Stream.of(element))
+                .collect(Collectors.toList());
+    }
+
+    private static class DecoratedLoadTester implements LoadTester {
+        private final LoadTester delegate;
+        private final List<Reporter> reporters;
+
+        private DecoratedLoadTester(LoadTester delegate, List<Reporter> reporters) {
+            this.delegate = delegate;
+            this.reporters = reporters;
+        }
+
+        @Override
+        public Result run(List<Request> requests) {
+            final Result result = delegate.run(requests);
+
+            reporters.forEach(reporter -> reporter.report(result));
+
+            return result;
+        }
+    }
+}

--- a/src/main/java/org/loadtest4j/decorator/Reporter.java
+++ b/src/main/java/org/loadtest4j/decorator/Reporter.java
@@ -1,7 +1,0 @@
-package org.loadtest4j.decorator;
-
-import org.loadtest4j.Result;
-
-public interface Reporter {
-    void report(Result result);
-}

--- a/src/main/java/org/loadtest4j/decorator/Reporter.java
+++ b/src/main/java/org/loadtest4j/decorator/Reporter.java
@@ -1,0 +1,7 @@
+package org.loadtest4j.decorator;
+
+import org.loadtest4j.Result;
+
+public interface Reporter {
+    void report(Result result);
+}

--- a/src/test/java/org/loadtest4j/BodyPartTest.java
+++ b/src/test/java/org/loadtest4j/BodyPartTest.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Category(UnitTest.class)
 public class BodyPartTest {
     @Test
-    public void testStringPart() {
+    public void shouldSupportStringPart() {
         final BodyPart bodyPart = BodyPart.string("foo", "abc");
 
         final String output = bodyPart.match(new BodyPart.Matcher<String>() {
@@ -31,7 +31,7 @@ public class BodyPartTest {
     }
 
     @Test
-    public void testFilePart() {
+    public void shouldSupportFilePart() {
         final BodyPart bodyPart = BodyPart.file(Paths.get("/tmp/foo.txt"));
 
         final String output = bodyPart.match(new BodyPart.Matcher<String>() {

--- a/src/test/java/org/loadtest4j/BodyTest.java
+++ b/src/test/java/org/loadtest4j/BodyTest.java
@@ -10,7 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Category(UnitTest.class)
 public class BodyTest {
     @Test
-    public void testStringBody() {
+    public void shouldSupportStringBody() {
         final Body body = Body.string("foo bar");
 
         assertThat(body.match(new MockBodyMatcher()))
@@ -18,7 +18,7 @@ public class BodyTest {
     }
 
     @Test
-    public void testBodyParts() {
+    public void shouldSupportBodyParts() {
         final BodyPart foo = BodyPart.string("foo", "abc");
         final BodyPart bar = BodyPart.string("bar", "def");
         final Body body = Body.multipart(foo, bar);
@@ -28,7 +28,7 @@ public class BodyTest {
     }
 
     @Test
-    public void testNoBodyParts() {
+    public void shouldSupportEmptyMultipartBody() {
         final Body body = Body.multipart();
 
         assertThat(body.match(new MockBodyMatcher()))

--- a/src/test/java/org/loadtest4j/LoadTesterExceptionTest.java
+++ b/src/test/java/org/loadtest4j/LoadTesterExceptionTest.java
@@ -9,14 +9,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Category(UnitTest.class)
 public class LoadTesterExceptionTest {
     @Test
-    public void testExceptionWithString() {
+    public void shouldWrapMessages() {
         final LoadTesterException e = new LoadTesterException("foo");
 
         assertThat(e).hasMessage("foo");
     }
 
     @Test
-    public void testExceptionWithWrappedException() {
+    public void shouldWrapCauses() {
         final Exception foo = new Exception();
         final LoadTesterException e = new LoadTesterException(foo);
 

--- a/src/test/java/org/loadtest4j/RequestTest.java
+++ b/src/test/java/org/loadtest4j/RequestTest.java
@@ -10,89 +10,76 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @Category(UnitTest.class)
 public class RequestTest {
-    @Test
-    public void testDefaultHeaders() {
-        final Request sut = Request.get("/pets");
-
-        assertThat(sut.getHeaders()).isEmpty();
-    }
 
     @Test
-    public void testDefaultBody() {
-        final Request sut = Request.get("/pets");
+    public void shouldHaveBody() {
+        final Request sut = Request.post("/pets");
 
         assertThat(sut.getBody().match(new MockBodyMatcher())).containsExactly("");
     }
 
     @Test
-    public void testGetPath() {
+    public void shouldHaveHeaders() {
+        final Request sut = Request.post("/pets");
+
+        assertThat(sut.getHeaders()).isEmpty();
+    }
+
+    @Test
+    public void shouldHaveMethod() {
+        assertSoftly(s -> {
+            s.assertThat(Request.get("/").getMethod()).as("GET").isEqualTo("GET");
+            s.assertThat(Request.post("/").getMethod()).as("POST").isEqualTo("POST");
+            s.assertThat(Request.put("/").getMethod()).as("PUT").isEqualTo("PUT");
+            s.assertThat(Request.delete("/").getMethod()).as("DELETE").isEqualTo("DELETE");
+            s.assertThat(Request.options("/").getMethod()).as("OPTIONS").isEqualTo("OPTIONS");
+            s.assertThat(Request.head("/").getMethod()).as("HEAD").isEqualTo("HEAD");
+            s.assertThat(Request.trace("/").getMethod()).as("TRACE").isEqualTo("TRACE");
+            s.assertThat(Request.patch("/").getMethod()).as("PATCH").isEqualTo("PATCH");
+            s.assertThat(Request.link("/").getMethod()).as("LINK").isEqualTo("LINK");
+            s.assertThat(Request.unlink("/").getMethod()).as("UNLINK").isEqualTo("UNLINK");
+        });
+    }
+
+    @Test
+    public void shouldHavePath() {
         final Request sut = Request.get("/pets");
 
         assertThat(sut.getPath()).isEqualTo("/pets");
     }
 
     @Test
-    public void testGet() {
-        assertThat(Request.get("/").getMethod()).isEqualTo("GET");
+    public void shouldHaveQueryParams() {
+        final Request sut = Request.get("/pets");
+
+        assertThat(sut.getQueryParams()).isEmpty();
     }
 
     @Test
-    public void testPost() {
-        assertThat(Request.post("/").getMethod()).isEqualTo("POST");
+    public void shouldBeImmutable() {
+        final Request sut = Request.get("/pets");
+
+        sut.withBody("foo");
+        sut.withQueryParam("foo", "bar");
+        sut.withHeader("Foo", "bar");
+        sut.withHeaders(Collections.singletonMap("Foo", "bar"));
+
+        assertThat(sut).isEqualToComparingFieldByFieldRecursively(Request.get("/pets"));
     }
 
     @Test
-    public void testPut() {
-        assertThat(Request.put("/").getMethod()).isEqualTo("PUT");
-    }
-
-    @Test
-    public void testDelete() {
-        assertThat(Request.delete("/").getMethod()).isEqualTo("DELETE");
-    }
-
-    @Test
-    public void testOptions() {
-        assertThat(Request.options("/").getMethod()).isEqualTo("OPTIONS");
-    }
-
-    @Test
-    public void testHead() {
-        assertThat(Request.head("/").getMethod()).isEqualTo("HEAD");
-    }
-
-    @Test
-    public void testTrace() {
-        assertThat(Request.trace("/").getMethod()).isEqualTo("TRACE");
-    }
-
-    @Test
-    public void testPatch() {
-        assertThat(Request.patch("/").getMethod()).isEqualTo("PATCH");
-    }
-
-    @Test
-    public void testLink() {
-        assertThat(Request.link("/").getMethod()).isEqualTo("LINK");
-    }
-
-    @Test
-    public void testUnlink() {
-        assertThat(Request.unlink("/").getMethod()).isEqualTo("UNLINK");
-    }
-
-    @Test
-    public void testWithBodyString() {
+    public void shouldBuildWithStringBody() {
         final Request sut = Request.post("/pets").withBody("{}");
 
         assertThat(sut.getBody().match(new MockBodyMatcher())).containsExactly("{}");
     }
 
     @Test
-    public void testWithBodyMultipart() {
+    public void shouldBuildWithMultipartBody() {
         final BodyPart part = BodyPart.string("foo", "bar");
 
         final Request sut = Request.post("/pets").withBody(part);
@@ -101,45 +88,15 @@ public class RequestTest {
     }
 
     @Test
-    public void testDoesNotCombineBodies() {
+    public void shouldBuildWithHeader() {
         final Request sut = Request.post("/pets")
-                .withBody("foo")
-                .withBody("bar");
-
-        assertThat(sut.getBody().match(new MockBodyMatcher())).containsExactly("bar");
-    }
-
-    @Test
-    public void testWithHeader() {
-        final Request sut = Request.post("/pets").withHeader("Content-Type", "application/json");
+                .withHeader("Content-Type", "application/json");
 
         assertThat(sut.getHeaders()).containsEntry("Content-Type", "application/json");
     }
 
     @Test
-    public void testWithHeaderMultipleInvocations() {
-        final Request sut = Request.get("/pets")
-                .withHeader("Accept", "application/json")
-                .withHeader("Referer", "https://example.com");
-
-        assertThat(sut.getHeaders())
-                .containsEntry("Accept", "application/json")
-                .containsEntry("Referer", "https://example.com");
-    }
-
-    @Test
-    public void testWithHeaderBehavesImmutably() {
-        final Request sut = Request.get("/pets");
-
-        final Map<String, String> headersBefore = sut.getHeaders();
-
-        sut.withHeader("Foo", "bar");
-
-        assertThat(headersBefore).doesNotContainKey("Foo");
-    }
-
-    @Test
-    public void testWithHeaders() {
+    public void shouldBuildWithHeaders() {
         final Map<String, String> headers = new HashMap<>();
         headers.put("Accept", "application/json");
         headers.put("Referer", "https://example.com");
@@ -153,18 +110,34 @@ public class RequestTest {
     }
 
     @Test
-    public void testWithHeadersBehavesImmutably() {
-        final Request sut = Request.get("/pets");
+    public void shouldBuildWithQueryParam() {
+        final Request sut = Request.get("/pets").withQueryParam("foo", "1");
 
-        final Map<String, String> headersBefore = sut.getHeaders();
-
-        sut.withHeaders(Collections.singletonMap("Foo", "bar"));
-
-        assertThat(headersBefore).doesNotContainKey("Foo");
+        assertThat(sut.getQueryParams()).containsEntry("foo", "1");
     }
 
     @Test
-    public void testCombinesHeaders() {
+    public void shouldNotCombineBodies() {
+        final Request sut = Request.post("/pets")
+                .withBody("foo")
+                .withBody("bar");
+
+        assertThat(sut.getBody().match(new MockBodyMatcher())).containsExactly("bar");
+    }
+
+    @Test
+    public void shouldCombineHeaderAndHeader() {
+        final Request sut = Request.get("/pets")
+                .withHeader("Accept", "application/json")
+                .withHeader("Referer", "https://example.com");
+
+        assertThat(sut.getHeaders())
+                .containsEntry("Accept", "application/json")
+                .containsEntry("Referer", "https://example.com");
+    }
+
+    @Test
+    public void shouldCombineHeaderAndHeaders() {
         final Request sut = Request.get("/pets")
                 .withHeader("Referer", "https://example.com")
                 .withHeaders(Collections.singletonMap("Accept", "application/json"));
@@ -175,14 +148,7 @@ public class RequestTest {
     }
 
     @Test
-    public void testWithQueryParam() {
-        final Request sut = Request.get("/pets").withQueryParam("foo", "1");
-
-        assertThat(sut.getQueryParams()).containsEntry("foo", "1");
-    }
-
-    @Test
-    public void testWithQueryParamMultipleInvocations() {
+    public void shouldCombineQueryParams() {
         final Request sut = Request.get("/pets")
                 .withQueryParam("foo", "1")
                 .withQueryParam("bar", "2");
@@ -190,16 +156,5 @@ public class RequestTest {
         assertThat(sut.getQueryParams())
                 .containsEntry("foo", "1")
                 .containsEntry("bar", "2");
-    }
-
-    @Test
-    public void testWithQueryParamBehavesImmutably() {
-        final Request sut = Request.get("/pets");
-
-        final Map<String, String> queryParamsBefore = sut.getQueryParams();
-
-        sut.withQueryParam("foo", "bar");
-
-        assertThat(queryParamsBefore).doesNotContainKey("foo");
     }
 }

--- a/src/test/java/org/loadtest4j/ResponseTimeTest.java
+++ b/src/test/java/org/loadtest4j/ResponseTimeTest.java
@@ -12,21 +12,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Category(UnitTest.class)
 public class ResponseTimeTest {
     @Test
-    public void testGetPercentile() {
+    public void shouldHavePercentileDistribution() {
         final ResponseTime responseTime = new ResponseTime(TestResponseTime.ZERO);
         
         assertThat(responseTime.getPercentile(90.5)).isEqualTo(Duration.ZERO);
     }
     
     @Test
-    public void testGetMax() {
+    public void shouldHaveMax() {
         final ResponseTime responseTime = new ResponseTime(TestResponseTime.ZERO);
         
         assertThat(responseTime.getMax()).isEqualTo(Duration.ZERO);
     }
 
     @Test
-    public void testGetMedian() {
+    public void shouldHaveMedian() {
         final ResponseTime responseTime = new ResponseTime(TestResponseTime.ZERO);
 
         assertThat(responseTime.getMedian()).isEqualTo(Duration.ZERO);

--- a/src/test/java/org/loadtest4j/decorator/LoadTesterDecoratorTest.java
+++ b/src/test/java/org/loadtest4j/decorator/LoadTesterDecoratorTest.java
@@ -11,6 +11,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @Category(UnitTest.class)
@@ -70,6 +71,15 @@ public class LoadTesterDecoratorTest {
             s.assertThat(stub2.getNumCalls()).isEqualTo(1);
             s.assertThat(reporter.getNumCalls()).isEqualTo(2);
         });
+    }
+
+    @Test
+    public void shouldBeImmutable() {
+        final LoadTesterDecorator decorator = new LoadTesterDecorator();
+
+        decorator.add(new StubReporter());
+
+        assertThat(decorator).isEqualToComparingFieldByField(new LoadTesterDecorator());
     }
 
     private static class StubReporter implements Reporter {

--- a/src/test/java/org/loadtest4j/decorator/LoadTesterDecoratorTest.java
+++ b/src/test/java/org/loadtest4j/decorator/LoadTesterDecoratorTest.java
@@ -1,0 +1,103 @@
+package org.loadtest4j.decorator;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.loadtest4j.LoadTester;
+import org.loadtest4j.Request;
+import org.loadtest4j.Result;
+import org.loadtest4j.junit.UnitTest;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@Category(UnitTest.class)
+public class LoadTesterDecoratorTest {
+
+    @Test
+    public void shouldDecorate() {
+        final StubReporter reporter = new StubReporter();
+        final StubLoadTester stubLoadTester = new StubLoadTester();
+
+        final LoadTester loadTester = new LoadTesterDecorator()
+                .add(reporter)
+                .decorate(stubLoadTester);
+
+        loadTester.run(Collections.emptyList());
+
+        assertSoftly(s -> {
+            s.assertThat(stubLoadTester.getNumCalls()).isEqualTo(1);
+            s.assertThat(reporter.getNumCalls()).isEqualTo(1);
+        });
+    }
+
+    @Test
+    public void shouldDecorateWithMultipleReporters() {
+        final StubReporter reporter1 = new StubReporter();
+        final StubReporter reporter2 = new StubReporter();
+        final StubLoadTester stubLoadTester = new StubLoadTester();
+
+        final LoadTester loadTester = new LoadTesterDecorator()
+                .add(reporter1)
+                .add(reporter2)
+                .decorate(stubLoadTester);
+
+        loadTester.run(Collections.emptyList());
+
+        assertSoftly(s -> {
+            s.assertThat(stubLoadTester.getNumCalls()).isEqualTo(1);
+            s.assertThat(reporter1.getNumCalls()).isEqualTo(1);
+            s.assertThat(reporter2.getNumCalls()).isEqualTo(1);
+        });
+    }
+
+    @Test
+    public void shouldDecorateMultipleLoadTesters() {
+        final StubReporter reporter = new StubReporter();
+        final LoadTesterDecorator decorator = new LoadTesterDecorator()
+                .add(reporter);
+
+        final StubLoadTester stub1 = new StubLoadTester();
+        decorator.decorate(stub1).run(Collections.emptyList());
+
+        final StubLoadTester stub2 = new StubLoadTester();
+        decorator.decorate(stub2).run(Collections.emptyList());
+
+        assertSoftly(s -> {
+            s.assertThat(stub1.getNumCalls()).isEqualTo(1);
+            s.assertThat(stub2.getNumCalls()).isEqualTo(1);
+            s.assertThat(reporter.getNumCalls()).isEqualTo(2);
+        });
+    }
+
+    private static class StubReporter implements Reporter {
+
+        private final AtomicLong numCalls = new AtomicLong();
+
+        @Override
+        public void report(Result result) {
+            numCalls.incrementAndGet();
+        }
+
+        long getNumCalls() {
+            return numCalls.longValue();
+        }
+    }
+
+    private static class StubLoadTester implements LoadTester {
+
+        private final AtomicLong numCalls = new AtomicLong();
+
+        @Override
+        public Result run(List<Request> requests) {
+            numCalls.incrementAndGet();
+            return null;
+        }
+
+        long getNumCalls() {
+            return numCalls.longValue();
+        }
+    }
+}

--- a/src/test/java/org/loadtest4j/driver/DriverRequestTest.java
+++ b/src/test/java/org/loadtest4j/driver/DriverRequestTest.java
@@ -16,27 +16,27 @@ public class DriverRequestTest {
     private final DriverRequest request = new DriverRequest(Body.string("{}"), Collections.singletonMap("Accept", "application/json"), "GET", "/", Collections.singletonMap("foo", "bar"));
 
     @Test
-    public void testGetBody() {
+    public void shouldHaveBody() {
         assertThat(request.getBody().match(new MockBodyMatcher())).containsExactly("{}");
     }
 
     @Test
-    public void testGetHeaders() {
+    public void shouldHaveHeaders() {
         assertThat(request.getHeaders()).containsEntry("Accept", "application/json");
     }
 
     @Test
-    public void testGetMethod() {
+    public void shouldHaveMethod() {
         assertThat(request.getMethod()).isEqualTo("GET");
     }
 
     @Test
-    public void testGetPath() {
+    public void shouldHavePath() {
         assertThat(request.getPath()).isEqualTo("/");
     }
 
     @Test
-    public void testGetQueryParams() {
+    public void shouldHaveQueryParams() {
         assertThat(request.getQueryParams()).containsEntry("foo", "bar");
     }
 }

--- a/src/test/java/org/loadtest4j/factory/DriverAdapterFactoryTest.java
+++ b/src/test/java/org/loadtest4j/factory/DriverAdapterFactoryTest.java
@@ -20,7 +20,7 @@ public class DriverAdapterFactoryTest {
     public ExpectedException thrown = ExpectedException.none();
 
     @Test
-    public void testCreateDriver() {
+    public void shouldCreateDriver() {
         // Given
         final DriverAdapterFactory factory = DriverAdapterFactory.defaultFactory();
 
@@ -35,7 +35,7 @@ public class DriverAdapterFactoryTest {
     }
 
     @Test
-    public void testCreateDriverWithMissingProperties() {
+    public void shouldThrowExceptionWhenPropertiesAreMissing() {
         final DriverAdapterFactory factory = DriverAdapterFactory.defaultFactory();
 
         thrown.expect(LoadTesterException.class);

--- a/src/test/java/org/loadtest4j/factory/DriverAdapterTest.java
+++ b/src/test/java/org/loadtest4j/factory/DriverAdapterTest.java
@@ -26,7 +26,7 @@ public class DriverAdapterTest {
     public ExpectedException thrown = ExpectedException.none();
 
     @Test
-    public void testRun() {
+    public void shouldRun() {
         // Given
         final SpyDriver driver = new SpyDriver(new NopDriver());
         final LoadTester loadTester = new DriverAdapter(driver);
@@ -41,7 +41,7 @@ public class DriverAdapterTest {
     }
 
     @Test
-    public void testRunPreservesRequestOrdering() {
+    public void shouldPreserveRequestOrdering() {
         // Given
         final SpyDriver driver = new SpyDriver(new NopDriver());
         final LoadTester loadTester = new DriverAdapter(driver);
@@ -56,22 +56,22 @@ public class DriverAdapterTest {
     }
 
     @Test
-    public void testGetPercentOk() {
+    public void shouldCalculatePercentOk() {
         assertThat(DriverAdapter.getPercentOk(2, 2)).isEqualTo(100);
     }
 
     @Test
-    public void testGetPercentOkAvoidsDivideByZero() {
+    public void shouldCalculatePercentOkAndAvoidDivideByZero() {
         assertThat(DriverAdapter.getPercentOk(0, 0)).isEqualTo(0);
     }
 
     @Test
-    public void testGetPercentOkWithErrors() {
+    public void shouldCalculatePercentOkWithErrors() {
         assertThat(DriverAdapter.getPercentOk(1, 4)).isEqualTo(25);
     }
 
     @Test
-    public void testGetPercentOkWithHugeNumbers() {
+    public void shouldCalculatePercentOkWithHugeNumbers() {
         final long ok = Long.MAX_VALUE / 2;
         final long total = Long.MAX_VALUE;
 
@@ -79,17 +79,17 @@ public class DriverAdapterTest {
     }
 
     @Test
-    public void testGetRequestsPerSecond() {
+    public void shouldCalculateRequestsPerSecond() {
         assertThat(DriverAdapter.getRequestsPerSecond(10, Duration.ofMillis(2500))).isEqualTo(4);
     }
 
     @Test
-    public void testGetRequestsPerSecondAvoidsDivideByZero() {
+    public void shouldCalculateRequestsPerSecondAndAvoidDivideByZero() {
         assertThat(DriverAdapter.getRequestsPerSecond(2, Duration.ZERO)).isEqualTo(0);
     }
 
     @Test
-    public void testPostprocessResult() {
+    public void shouldPostprocessResult() {
         final DriverResult input = new TestDriverResult(Duration.ofMillis(2500), 6, 4, new TestResponseTime(Duration.ZERO));
 
         final Result result = DriverAdapter.postprocessResult(input);

--- a/src/test/java/org/loadtest4j/factory/DriverFactorySupplierTest.java
+++ b/src/test/java/org/loadtest4j/factory/DriverFactorySupplierTest.java
@@ -21,7 +21,7 @@ public class DriverFactorySupplierTest {
     public ExpectedException thrown = ExpectedException.none();
 
     @Test
-    public void testGet() {
+    public void shouldSupplyFactory() {
         final Iterable<DriverFactory> singleFinder = Collections.singletonList(new NopDriverFactory());
         final DriverFactorySupplier supplier = new DriverFactorySupplier(singleFinder);
 
@@ -31,7 +31,7 @@ public class DriverFactorySupplierTest {
     }
 
     @Test
-    public void testGetWithNoDriverFactories() {
+    public void shouldThrowExceptionWhenNoFactoriesAreFound() {
         final Iterable<DriverFactory> emptyFinder = Collections.emptyList();
         final DriverFactorySupplier supplier = new DriverFactorySupplier(emptyFinder);
 
@@ -42,7 +42,7 @@ public class DriverFactorySupplierTest {
     }
 
     @Test
-    public void testGetWithMoreThanOneDriverFactory() {
+    public void shouldThrowExceptionWhenMultipleFactoriesAreFound() {
         final Iterable<DriverFactory> duplicateFinder = Arrays.asList(new NopDriverFactory(), new NopDriverFactory());
         final DriverFactorySupplier supplier = new DriverFactorySupplier(duplicateFinder);
 

--- a/src/test/java/org/loadtest4j/factory/LoadTesterFactoryTest.java
+++ b/src/test/java/org/loadtest4j/factory/LoadTesterFactoryTest.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class LoadTesterFactoryTest {
 
     @Test
-    public void testPublicApi() {
+    public void shouldGetLoadTester() {
         // The static factory method will reference loadtest4j.properties in the test resources
         final LoadTester loadTester = LoadTesterFactory.getLoadTester();
 

--- a/src/test/java/org/loadtest4j/factory/ValidatingDriverTest.java
+++ b/src/test/java/org/loadtest4j/factory/ValidatingDriverTest.java
@@ -24,7 +24,7 @@ public class ValidatingDriverTest {
     public ExpectedException thrown = ExpectedException.none();
 
     @Test
-    public void testRun() {
+    public void shouldRun() {
         // Given
         final StubDriver stubDriver = new StubDriver();
         final Driver sut = new ValidatingDriver(stubDriver);
@@ -40,7 +40,7 @@ public class ValidatingDriverTest {
     }
 
     @Test
-    public void testRunWithNegativeOkValue() {
+    public void shouldThrowExceptionWhenOkIsNegative() {
         // Given
         final StubDriver stubDriver = new StubDriver();
         final Driver sut = new ValidatingDriver(stubDriver);
@@ -56,7 +56,7 @@ public class ValidatingDriverTest {
     }
 
     @Test
-    public void testRunWithNegativeKoValue() {
+    public void shouldThrowExceptionWhenKoIsNegative() {
         // Given
         final StubDriver stubDriver = new StubDriver();
         final Driver sut = new ValidatingDriver(stubDriver);

--- a/src/test/java/org/loadtest4j/utils/PropertiesResourceTest.java
+++ b/src/test/java/org/loadtest4j/utils/PropertiesResourceTest.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Category(IntegrationTest.class)
 public class PropertiesResourceTest {
     @Test
-    public void getProperties() {
+    public void shouldSupplyProperties() {
         final PropertiesResource sut = new PropertiesResource("/props/example.properties");
 
         final Properties properties = sut.getProperties();
@@ -22,7 +22,7 @@ public class PropertiesResourceTest {
     }
 
     @Test
-    public void getEmptyProperties() {
+    public void shouldSupplyEmptyPropertiesByDefault() {
         final PropertiesResource sut = new PropertiesResource("/props/fake.properties");
 
         final Properties properties = sut.getProperties();

--- a/src/test/java/org/loadtest4j/utils/PropertiesSubsetTest.java
+++ b/src/test/java/org/loadtest4j/utils/PropertiesSubsetTest.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Category(UnitTest.class)
 public class PropertiesSubsetTest {
     @Test
-    public void testGetSubsetAndStripPrefix() {
+    public void shouldGetSubsetAndStripPrefix() {
         final Map<String, String> props = new ConcurrentHashMap<>();
         props.put("foo", "1");
         props.put("foo.bar", "2");

--- a/src/test/java/org/loadtest4j/utils/PropertyTest.java
+++ b/src/test/java/org/loadtest4j/utils/PropertyTest.java
@@ -9,14 +9,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Category(UnitTest.class)
 public class PropertyTest {
     @Test
-    public void testGetKey() {
+    public void shouldHaveKey() {
         final Property property = new Property("foo", "bar");
 
         assertThat(property.getKey()).isEqualTo("foo");
     }
 
     @Test
-    public void testGetValue() {
+    public void shouldHaveValue() {
         final Property property = new Property("foo", "bar");
 
         assertThat(property.getValue()).isEqualTo("bar");


### PR DESCRIPTION
Let the user attach custom reporters to a LoadTester, which will run after each invocation of its `run` method.