### PR TITLE
Allow LoadTester to be constructed in code

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -62,7 +62,9 @@ Use **either** the Factory **or** the Builder. (Note: The options available, and
 #### Factory
 
 ```java
-LoadTester loadTester = LoadTesterFactory.getLoadTester();
+public class PetStoreLT {
+    private static LoadTester loadTester = LoadTesterFactory.getLoadTester();
+}
 ```
 
 ```properties
@@ -76,10 +78,12 @@ loadtest4j.driver.usersPerSecond = 1
 #### Builder
 
 ```java
-LoadTester loadTester = GatlingBuilder.withUrl("https://example.com")
-                                      .withDuration(Duration.ofSeconds(60))
-                                      .withUsersPerSecond(1)
-                                      .build();
+public class PetStoreLT {
+    private static LoadTester loadTester = GatlingBuilder.withUrl("https://example.com")
+                                                         .withDuration(Duration.ofSeconds(60))
+                                                         .withUsersPerSecond(1)
+                                                         .build();
+}
 ``` 
 
 ### 3. Write load tests
@@ -89,7 +93,7 @@ Write load tests with your favorite language, test framework, and assertions:
 ```java
 public class PetStoreLT {
 
-    private static final LoadTester loadTester = /* see step 2 */ ;
+    private static LoadTester loadTester = /* see step 2 */ ;
 
     @Test
     public void shouldFindPets() {
@@ -181,7 +185,7 @@ Note: Custom behaviors are not included with the core library.
 
 ```java
 public class PetStoreLT {
-    private static final LoadTester loadTester = new LoadTesterDecorator()
+    private static LoadTester loadTester = new LoadTesterDecorator()
         .add(new Slf4jReporter())
         .add(new HtmlReporter())
         .decorate(LoadTesterFactory.getLoadTester());

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,7 +44,7 @@ With a new or existing Maven project open in your favorite editor...
 
 ### 1. Add the library
 
-Add a load test driver library from the [registry](registry.md) to your Maven project POM:
+Add a load test driver library from the [registry](registry.md) to your Maven project POM.
 
 ```xml
 <!-- Example: https://github.com/loadtest4j/loadtest4j-gatling -->
@@ -62,9 +62,7 @@ Use **either** the Factory **or** the Builder. (Note: The options available, and
 #### Factory
 
 ```java
-public class PetStoreLT {
-    private static LoadTester loadTester = LoadTesterFactory.getLoadTester();
-}
+LoadTester loadTester = LoadTesterFactory.getLoadTester();
 ```
 
 ```properties
@@ -78,22 +76,20 @@ loadtest4j.driver.usersPerSecond = 1
 #### Builder
 
 ```java
-public class PetStoreLT {
-    private static LoadTester loadTester = GatlingBuilder.withUrl("https://example.com")
-                                                         .withDuration(Duration.ofSeconds(60))
-                                                         .withUsersPerSecond(1)
-                                                         .build();
-}
+LoadTester loadTester = GatlingBuilder.withUrl("https://example.com")
+                                      .withDuration(Duration.ofSeconds(60))
+                                      .withUsersPerSecond(1)
+                                      .build();
 ``` 
 
 ### 3. Write load tests
  
-Write load tests with your favorite language, test framework, and assertions:
+Write load tests with your favorite language, test framework, and assertions.
     
 ```java
 public class PetStoreLT {
 
-    private static LoadTester loadTester = /* see step 2 */ ;
+    private static final LoadTester loadTester = /* see step 2 */ ;
 
     @Test
     public void shouldFindPets() {
@@ -111,7 +107,7 @@ public class PetStoreLT {
 
 ### 4. Declare your load tests
 
-Tell Maven how to discover and run your load tests:
+Tell Maven how to discover and run your load tests.
 
 ```xml
 <plugin>
@@ -148,7 +144,7 @@ Tell Maven how to discover and run your load tests:
 
 ### 5. Run the tests
  
-Run the tests with Maven or your IDE:
+Run the tests with Maven or your IDE.
 
 ```bash
 # Run all tests
@@ -165,15 +161,10 @@ mvn test-compile surefire:test@load
 Attach an arbitrary number of string parts or file parts to the multipart request body.
 
 ```java
-public class PetStoreLT {
-    @Test
-    public void shouldAddPet() {
-        BodyPart stringPart = BodyPart.string("name", "content");
-        BodyPart filePart = BodyPart.file(Paths.get("foo.txt"));
-        
-        Request request = Request.post("/pets").withBody(stringPart, filePart);
-    }
-}
+BodyPart stringPart = BodyPart.string("name", "content");
+BodyPart filePart = BodyPart.file(Paths.get("foo.txt"));
+
+Request request = Request.post("/pets").withBody(stringPart, filePart);
 ```
 
 ### Decorator
@@ -184,10 +175,8 @@ Attach custom behaviors to a `LoadTester` using the decorator. The behaviors wil
 Note: Custom behaviors are not included with the core library.
 
 ```java
-public class PetStoreLT {
-    private static LoadTester loadTester = new LoadTesterDecorator()
+LoadTester loadTester = new LoadTesterDecorator()
         .add(new Slf4jReporter())
         .add(new HtmlReporter())
         .decorate(LoadTesterFactory.getLoadTester());
-}
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,12 +40,12 @@ The benefits include...
 
 ## Usage
 
+With a new or existing Maven project open in your favorite editor...
+
 ### 1. Add the library
 
-Open your Web service project - or make a new project.
+Add a load test driver library from the [registry](registry.md) to your Maven project POM:
 
-Then add a load test driver from the [registry](registry.md) to your project POM:
-    
 ```xml
 <!-- Example: https://github.com/loadtest4j/loadtest4j-gatling -->
 <dependency>
@@ -57,7 +57,7 @@ Then add a load test driver from the [registry](registry.md) to your project POM
 
 ### 2. Create the load tester
 
-Use **either** the Factory **or** the Builder. (Note: The name of the builder class, and options available, will depend on the driver used.)
+Use **either** the Factory **or** the Builder. (Note: The options available, and builder class name, depend on the driver used.)
 
 #### Factory
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,92 +40,119 @@ The benefits include...
 
 ## Usage
 
-1. **Open your Web service project** - or make a new project.
+### 1. Add the library
 
-2. **Add a load test driver** from the [registry](registry.md) to your project:
-    
-    ```xml
-    <!-- Example: https://github.com/loadtest4j/loadtest4j-gatling -->
-    <dependency>
-        <groupId>org.loadtest4j.drivers</groupId>
-        <artifactId>loadtest4j-gatling</artifactId>
-        <scope>test</scope>
-    </dependency>
-    ```
+Open your Web service project - or make a new project.
 
-3. **Configure the library** in `src/test/resources/loadtest4j.properties`:
+Then add a load test driver from the [registry](registry.md) to your project POM:
     
-    ```properties
-    loadtest4j.driver.duration = 60
-    loadtest4j.driver.url = https://example.com
-    loadtest4j.driver.usersPerSecond = 1
-    ```
+```xml
+<!-- Example: https://github.com/loadtest4j/loadtest4j-gatling -->
+<dependency>
+    <groupId>org.loadtest4j.drivers</groupId>
+    <artifactId>loadtest4j-gatling</artifactId>
+    <scope>test</scope>
+</dependency>
+```
+
+### 2. Create the load tester
+
+Use **either** the Factory **or** the Builder. (Note: The name of the builder class, and options available, will depend on the driver used.)
+
+#### Factory
+
+```java
+LoadTester loadTester = LoadTesterFactory.getLoadTester();
+```
+
+```properties
+# src/test/resources/loadtest4j.properties
+
+loadtest4j.driver.duration = 60
+loadtest4j.driver.url = https://example.com
+loadtest4j.driver.usersPerSecond = 1
+```
+
+#### Builder
+
+```java
+LoadTester loadTester = GatlingBuilder.withUrl("https://example.com")
+                                      .withDuration(Duration.ofSeconds(60))
+                                      .withUsersPerSecond(1)
+                                      .build();
+``` 
+
+### 3. Write load tests
+ 
+Write load tests with your favorite language, test framework, and assertions:
     
-4. **Write a load test** with your favorite language, test framework, and assertions:
-    
-    ```java
-    public class PetStoreLT {
-    
-        private static final LoadTester loadTester = LoadTesterFactory.getLoadTester();
-    
-        @Test
-        public void shouldFindPets() {
-            List<Request> requests = List.of(Request.get("/pet/findByStatus")
-                                                    .withHeader("Accept", "application/json")
-                                                    .withQueryParam("status", "available"));
-    
-            Result result = loadTester.run(requests);
-    
-            assertThat(result.getResponseTime().getPercentile(90))
-                .isLessThanOrEqualTo(Duration.ofMillis(500));
-        }
+```java
+public class PetStoreLT {
+
+    private static final LoadTester loadTester = /* see step 2 */ ;
+
+    @Test
+    public void shouldFindPets() {
+        List<Request> requests = List.of(Request.get("/pet/findByStatus")
+                                                .withHeader("Accept", "application/json")
+                                                .withQueryParam("status", "available"));
+
+        Result result = loadTester.run(requests);
+
+        assertThat(result.getResponseTime().getPercentile(90))
+            .isLessThanOrEqualTo(Duration.ofMillis(500));
     }
-    ```
+}
+```
 
-5. **Declare your load test** to Maven:
+### 4. Declare your load tests
 
-    ```xml
-    <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <executions>
-            <execution>
-                <id>integration</id>
-                <phase>integration-test</phase>
-                <goals>
-                    <goal>test</goal>
-                </goals>
-                <configuration>
-                    <includes>
-                        <include>**/*IT.java</include>
-                    </includes>
-                </configuration>
-            </execution>
-            <execution>
-                <id>load</id>
-                <phase>integration-test</phase>
-                <goals>
-                    <goal>test</goal>
-                </goals>
-                <configuration>
-                    <includes>
-                        <include>**/*LT.java</include>
-                    </includes>
-                </configuration>
-            </execution>
-        </executions>
-    </plugin>
-    ```
+Tell Maven how to discover and run your load tests:
 
-6. **Run the test** with Maven or your IDE:
+```xml
+<plugin>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-surefire-plugin</artifactId>
+    <executions>
+        <execution>
+            <id>integration</id>
+            <phase>integration-test</phase>
+            <goals>
+                <goal>test</goal>
+            </goals>
+            <configuration>
+                <includes>
+                    <include>**/*IT.java</include>
+                </includes>
+            </configuration>
+        </execution>
+        <execution>
+            <id>load</id>
+            <phase>integration-test</phase>
+            <goals>
+                <goal>test</goal>
+            </goals>
+            <configuration>
+                <includes>
+                    <include>**/*LT.java</include>
+                </includes>
+            </configuration>
+        </execution>
+    </executions>
+</plugin>
+```
 
-    ```bash
-    # Run all tests
-    mvn verify
-    
-    # Run load tests
-    mvn test-compile surefire:test@load
-    ```
+### 5. Run the tests
+ 
+Run the tests with Maven or your IDE:
+
+```bash
+# Run all tests
+mvn verify
+
+# Only run load tests
+mvn test-compile surefire:test@load
+```
 
 ## Advanced usage
 

--- a/src/main/java/org/loadtest4j/factory/LoadTesterBuilder.java
+++ b/src/main/java/org/loadtest4j/factory/LoadTesterBuilder.java
@@ -1,0 +1,17 @@
+package org.loadtest4j.factory;
+
+import org.loadtest4j.LoadTester;
+import org.loadtest4j.driver.Driver;
+
+/**
+ * A mechanism to construct a LoadTester directly in code.
+ */
+public abstract class LoadTesterBuilder {
+
+    protected abstract Driver buildDriver();
+
+    public LoadTester build() {
+        final Driver driver = buildDriver();
+        return new DriverAdapter(new ValidatingDriver(driver));
+    }
+}

--- a/src/test/java/org/loadtest4j/factory/LoadTesterBuilderTest.java
+++ b/src/test/java/org/loadtest4j/factory/LoadTesterBuilderTest.java
@@ -1,0 +1,33 @@
+package org.loadtest4j.factory;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.loadtest4j.LoadTester;
+import org.loadtest4j.driver.Driver;
+import org.loadtest4j.junit.UnitTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Category(UnitTest.class)
+public class LoadTesterBuilderTest {
+
+    @Test
+    public void shouldBuild() {
+        final MockBuilder builder = new MockBuilder();
+        final LoadTester lt = builder.build();
+
+        assertThat(lt).isNotNull();
+        assertThat(builder.calls).isEqualTo(1);
+    }
+
+    private static class MockBuilder extends LoadTesterBuilder {
+
+        private int calls = 0;
+
+        @Override
+        protected Driver buildDriver() {
+            calls += 1;
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Allow LoadTester to be constructed in code, without separate configuration.

Fixes #109 by supporting both a Factory and a Builder API. Clients can choose which to use based on whichever is more helpful for them.